### PR TITLE
Update config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: "🙋‍♀️ Question"
     url: https://github.com/orgs/foxglove/discussions/new/choose
-    about: Search discussions or ask our community for help
+    about: Ask our community for help
   - name: "🚀 Feature request"
     url: https://github.com/orgs/foxglove/discussions/new/choose
     about: Search existing feature requests or share a new idea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Ask our community for help
   - name: "🚀 Feature request"
     url: https://github.com/orgs/foxglove/discussions/new/choose
-    about: Search existing feature requests or share a new idea
+    about: Share a new idea
   - name: "📚 Stack Exchange"
     url: https://robotics.stackexchange.com/questions/ask
     about: Get help from the robotics community

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: "🙋‍♀️ Question"
-    url: https://github.com/orgs/foxglove/discussions
+    url: https://github.com/orgs/foxglove/discussions/new/choose
     about: Search discussions or ask our community for help
   - name: "🚀 Feature request"
-    url: https://github.com/orgs/foxglove/discussions
+    url: https://github.com/orgs/foxglove/discussions/new/choose
     about: Search existing feature requests or share a new idea
   - name: "📚 Stack Exchange"
     url: https://robotics.stackexchange.com/questions/ask


### PR DESCRIPTION
Send users to the `/new/choose` page of discussions when they click on "Questions" or "Features". The idea is that a user already knows they want to ask a question or feature so this is one less click for them. They don't need to land on the generic discussions page and then realize to click "new discussion".

The downside is they are less likely to search the other discussions since they don't see them with this flow.