### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
-### Public-Facing Changes
+### Changelog
+<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 
-<!-- describe any changes to the public interface or APIs, or write "None" -->
 
 ### Description
+<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
 
-<!-- describe what has changed, and motivation behind those changes -->
 
-<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
+<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,21 @@
 ### Changelog
 <!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 
-
 ### Description
+
 <!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
 
+<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->
+
+<table><tr><th>Before</th><th>After</th></tr><tr><td>
+
+<!--before content goes here-->
+
+</td><td>
+
+<!--after content goes here-->
+
+</td></tr></table>
 
 <!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
+


### PR DESCRIPTION
Rename the `public facing changes` section to `Changelog` and update the description to better guide PR authors on how that content will be used.

Update the guide in the `Description` to language which I hope solicits a more thoughtful description.