### PR TITLE
PR template: move description section to top, remove heading

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,3 @@
-### Changelog
-<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
-
-### Docs
-
-<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
-
-### Description
-
 <!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
 
 <!-- In addition to unit tests, describe any manual testing you did to validate this change. -->
@@ -21,5 +12,11 @@
 
 </td></tr></table>
 
-<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->
+### Changelog
+<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
 
+### Docs
+
+<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
+
+<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->


### PR DESCRIPTION

Problem: When I have finished a patch set and want to create a PR, my desire is to open the link and start typing my reasoning immediately. However, I find the prompt to fill out entries for changelog and docs first distracting.

Solution: remove the "Description" heading and move the description section to the top. When the page is opened, the cursor appears in the description area, and it's seamless to start typing.

Also, if a PR consists of one commit with a message, that message will automatically appear where it should in the PR description.

### Changelog
None.

### Docs

None.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

